### PR TITLE
Fix breadcrumb not dynamically updating

### DIFF
--- a/projects/ng7-mat-breadcrumb/src/lib/breadcrumb.model.ts
+++ b/projects/ng7-mat-breadcrumb/src/lib/breadcrumb.model.ts
@@ -1,5 +1,5 @@
-
 export interface Breadcrumb {
-    label: string;
-    url: string;
-  }
+  label: string;
+  url: string;
+  displayText: string;
+}

--- a/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.html
+++ b/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.html
@@ -3,8 +3,8 @@
         <mat-list-item>
             <span class="mat-bread-crumb-spacer">
                 <span *ngFor="let item of breadcrumb; let i = index">
-                    <a *ngIf="item?.url" [routerLink]="item?.url" class="mat-bread-crumb-list-item">{{ item.label }}</a>
-                    <span *ngIf="!item?.url" class="mat-bread-crumb-list-item">{{ item.label }}</span>
+                    <a *ngIf="item?.url" [routerLink]="item?.url" class="mat-bread-crumb-list-item">{{ item.displayText }}</a>
+                    <span *ngIf="!item?.url" class="mat-bread-crumb-list-item">{{ item.displayText }}</span>
                     <span *ngIf="breadcrumb.length !== i+1"> / </span>
                 </span>
             </span>


### PR DESCRIPTION
Don't expect you to straight merge this in. This is showing how to fix the issue in https://github.com/rajaramtt/ng7-dynamic-breadcrumb/issues/5

The issue was you would override the label field which held the {{}} used to know how to replace the text. So if the labels were updated again without a page change, it wouldn't know how to replace text anymore. There are a number of ways you could store the original labels so they don't get overridden. I just did a quick example.

I'll leave comments on the important lines, apologies that prettier took over and did some reformatting.