### PR TITLE
Fixed overwriting breadcrumbs by parent component

### DIFF
--- a/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.spec.ts
+++ b/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { NgDynamicBreadcrumbComponent } from './ng-dynamic-breadcrumb.component';
 
@@ -6,7 +6,7 @@ describe('NgDynamicBreadcrumbComponent', () => {
   let component: NgDynamicBreadcrumbComponent;
   let fixture: ComponentFixture<NgDynamicBreadcrumbComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ NgDynamicBreadcrumbComponent ]
     })

--- a/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.ts
+++ b/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.ts
@@ -50,7 +50,9 @@ export class NgDynamicBreadcrumbComponent implements OnInit {
     });
 
     this.ngDynamicBreadcrumbService.newBreadcrumb.subscribe((breadcrumb: Breadcrumb[]) => {
-      this.updateData(this.activatedRoute, breadcrumb);
+      if (breadcrumb.length > 0) {
+        this.updateData(this.activatedRoute, breadcrumb);
+      }
     });
   }
   breadCrumbData(): void {

--- a/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.service.spec.ts
+++ b/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.service.spec.ts
@@ -6,7 +6,7 @@ describe('NgDynamicBreadcrumbService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: NgDynamicBreadcrumbService = TestBed.get(NgDynamicBreadcrumbService);
+    const service: NgDynamicBreadcrumbService = TestBed.inject(NgDynamicBreadcrumbService);
     expect(service).toBeTruthy();
   });
 });

--- a/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.component.spec.ts
+++ b/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Ng7BootstrapBreadcrumbComponent } from './ng7-bootstrap-breadcrumb.component';
 
@@ -6,7 +6,7 @@ describe('Ng7BootstrapBreadcrumbComponent', () => {
   let component: Ng7BootstrapBreadcrumbComponent;
   let fixture: ComponentFixture<Ng7BootstrapBreadcrumbComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ Ng7BootstrapBreadcrumbComponent ]
     })

--- a/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.component.ts
+++ b/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.component.ts
@@ -49,7 +49,9 @@ export class Ng7BootstrapBreadcrumbComponent implements OnInit {
     });
 
     this.ng7BootstrapBreadcrumbService.newBreadcrumb.subscribe((breadcrumb: Breadcrumb[]) => {
-      this.updateData(this.activatedRoute, breadcrumb);
+      if (breadcrumb.length > 0) {
+        this.updateData(this.activatedRoute, breadcrumb);
+      }
     });
   }
 

--- a/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.service.spec.ts
+++ b/projects/ng7-bootstrap-breadcrumb/src/lib/ng7-bootstrap-breadcrumb.service.spec.ts
@@ -6,7 +6,7 @@ describe('Ng7BootstrapBreadcrumbService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: Ng7BootstrapBreadcrumbService = TestBed.get(Ng7BootstrapBreadcrumbService);
+    const service: Ng7BootstrapBreadcrumbService = TestBed.inject(Ng7BootstrapBreadcrumbService);
     expect(service).toBeTruthy();
   });
 });

--- a/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.component.spec.ts
+++ b/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Ng7DynamicBreadcrumbComponent } from './ng7-dynamic-breadcrumb.component';
 
@@ -6,7 +6,7 @@ describe('Ng7DynamicBreadcrumbComponent', () => {
   let component: Ng7DynamicBreadcrumbComponent;
   let fixture: ComponentFixture<Ng7DynamicBreadcrumbComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ Ng7DynamicBreadcrumbComponent ]
     })

--- a/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.component.ts
+++ b/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.component.ts
@@ -50,7 +50,9 @@ export class Ng7DynamicBreadcrumbComponent implements OnInit {
     });
 
     this.ng7DynamicBreadcrumbService.newBreadcrumb.subscribe((breadcrumb: Breadcrumb[]) => {
-      this.updateData(this.activatedRoute, breadcrumb);
+      if (breadcrumb.length > 0) {
+        this.updateData(this.activatedRoute, breadcrumb);
+      }
     });
   }
 

--- a/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.service.spec.ts
+++ b/projects/ng7-dynamic-breadcrumb/src/lib/ng7-dynamic-breadcrumb.service.spec.ts
@@ -6,7 +6,7 @@ describe('Ng7DynamicBreadcrumbService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: Ng7DynamicBreadcrumbService = TestBed.get(Ng7DynamicBreadcrumbService);
+    const service: Ng7DynamicBreadcrumbService = TestBed.inject(Ng7DynamicBreadcrumbService);
     expect(service).toBeTruthy();
   });
 });

--- a/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.spec.ts
+++ b/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Ng7MatBreadcrumbComponent } from './ng7-mat-breadcrumb.component';
 
@@ -6,7 +6,7 @@ describe('Ng7MatBreadcrumbComponent', () => {
   let component: Ng7MatBreadcrumbComponent;
   let fixture: ComponentFixture<Ng7MatBreadcrumbComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ Ng7MatBreadcrumbComponent ]
     })

--- a/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.ts
+++ b/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.component.ts
@@ -49,7 +49,9 @@ export class Ng7MatBreadcrumbComponent implements OnInit {
     });
 
     this.ng7MatBreadcrumbService.newBreadcrumb.subscribe((breadcrumb: Breadcrumb[]) => {
-      this.updateData(this.activatedRoute, breadcrumb);
+      if (breadcrumb.length > 0) {
+        this.updateData(this.activatedRoute, breadcrumb);
+      }
     });
   }
 

--- a/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.service.spec.ts
+++ b/projects/ng7-mat-breadcrumb/src/lib/ng7-mat-breadcrumb.service.spec.ts
@@ -6,7 +6,7 @@ describe('Ng7MatBreadcrumbService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: Ng7MatBreadcrumbService = TestBed.get(Ng7MatBreadcrumbService);
+    const service: Ng7MatBreadcrumbService = TestBed.inject(Ng7MatBreadcrumbService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,9 +1,9 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PageComponent } from './page.component';
 
@@ -6,7 +6,7 @@ describe('PageComponent', () => {
   let component: PageComponent;
   let fixture: ComponentFixture<PageComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ PageComponent ]
     })

--- a/src/app/page2/page2.component.spec.ts
+++ b/src/app/page2/page2.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Page2Component } from './page2.component';
 
@@ -6,7 +6,7 @@ describe('Page2Component', () => {
   let component: Page2Component;
   let fixture: ComponentFixture<Page2Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ Page2Component ]
     })

--- a/src/app/page3/page3.component.spec.ts
+++ b/src/app/page3/page3.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Page3Component } from './page3.component';
 
@@ -6,7 +6,7 @@ describe('Page3Component', () => {
   let component: Page3Component;
   let fixture: ComponentFixture<Page3Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ Page3Component ]
     })


### PR DESCRIPTION
Fixed overwriting breadcrumbs by parent component while breadcrumbs are empty.
In other case it works properly as before.
Fix tested in different cases on large app.