### PR TITLE
add ability to pass query params

### DIFF
--- a/projects/ng-dynamic-breadcrumb/src/lib/breadcrumb.model.ts
+++ b/projects/ng-dynamic-breadcrumb/src/lib/breadcrumb.model.ts
@@ -1,5 +1,5 @@
-
 export interface Breadcrumb {
-    label: string;
-    url: string;
-  }
+  label: string;
+  url: string;
+  queryParams?: { [key: string]: string };
+}

--- a/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.html
+++ b/projects/ng-dynamic-breadcrumb/src/lib/ng-dynamic-breadcrumb.component.html
@@ -1,7 +1,7 @@
 <ul class="custom-bread-crumb" [ngStyle]="{'background-color': bgColor}">
   <span *ngFor="let item of breadcrumb; let i = index">
       <li [ngStyle]="{'font-size': fontSize}">
-          <a *ngIf="item?.url" [routerLink]="item?.url" [ngStyle]="{'color': fontColor}">{{ item.label }}</a>
+          <a *ngIf="item?.url" [routerLink]="item?.url" [queryParams]="item?.queryParams" [ngStyle]="{'color': fontColor}">{{ item.label }}</a>
           <span *ngIf="!item?.url" [ngStyle]="{'color': lastLinkColor}">{{ item.label }}</span>
           <span class="line" *ngIf="breadcrumb.length !== i+1">{{symbol}}</span>
       </li>


### PR DESCRIPTION
**What does this implement/fix?**

Ability to pass query params as extra option:
```
{
        label: 'Example'
        url: '/example',
        queryParams: {param: 'foo'}
}
```